### PR TITLE
fix nil annotation pointers panics

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -39,23 +39,24 @@ func userResource(u *client.User) (*v2.Resource, error) {
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	var annos annotations.Annotations
+
 	usersResponse, ratelimitData, err := o.client.ListUsers(ctx, pToken.Token)
 	if err != nil {
 		return nil, "", nil, err
 	}
-	var annos *annotations.Annotations
-	annos = annos.WithRateLimiting(ratelimitData)
+	annos.WithRateLimiting(ratelimitData)
 
 	rv := make([]*v2.Resource, 0, len(usersResponse.Users))
 	for _, u := range usersResponse.Users {
 		resource, err := userResource(u)
 		if err != nil {
-			return nil, "", *annos, fmt.Errorf("baton-ramp: failed to create resource for user %s: %w", u.ID, err)
+			return nil, "", annos, fmt.Errorf("baton-ramp: failed to create resource for user %s: %w", u.ID, err)
 		}
 		rv = append(rv, resource)
 	}
 
-	return rv, usersResponse.Pagination, *annos, nil
+	return rv, usersResponse.Pagination, annos, nil
 }
 
 // Entitlements always returns an empty slice for users.


### PR DESCRIPTION
Panicked here:

https://github.com/ConductorOne/baton-sdk/blob/main/pkg/annotations/annotations.go#L44

```
activity for SYNC_TASK_QUEUE [panic]:
github.com/conductorone/baton-sdk/pkg/annotations.(*Annotations).Update(0x0, {0xdab1bc0, 0x400ba8f9a0})
	/xsrc/vendor/github.com/conductorone/baton-sdk/pkg/annotations/annotations.go:44 +0x34
github.com/conductorone/baton-sdk/pkg/annotations.(*Annotations).WithRateLimiting(...)
	/xsrc/vendor/github.com/conductorone/baton-sdk/pkg/annotations/annotations.go:123
github.com/conductorone/baton-ramp/pkg/connector.(*userBuilder).List(0x0?, {0xdbbd3e8?, 0x400f43bb30?}, 0xc7fcd5a?, 0x500000001?)
	/xsrc/vendor/github.com/conductorone/baton-ramp/pkg/connector/users.go:47 +0x54
github.com/conductorone/baton-sdk/pkg/connectorbuilder.(*builderImpl).ListResources(0x400b1cce60, {0xdbbd3e8?, 0x40085e2ba0?}, 0x400d91a930)
	/xsrc/vendor/github.com/conductorone/baton-sdk/pkg/connectorbuilder/connectorbuilder.go:689 +0x14c
gitlab.com/ductone/c1/pkg/connector/manager.(*v2ConnectorWrapper).listResources(0x4006b5a740?, {0xdbbd3e8, 0x40085e2ba0}, 0x400d91a930, {0x0?, 0x0?, 0x0?})
	/xsrc/pkg/connector/manager/resources_v2.go:40 +0xa0
gitlab.com/ductone/c1/pkg/connector/manager.(*v2ConnectorWrapper).ListResources(0x4006b5a740, {0xdbbd3e8, 0x40085e2ba0}, 0x400d91a930, {0x0, 0x0, 0x0})
	/xsrc/pkg/connector/manager/resources_v2.go:67 +0x124
github.com/conductorone/baton-sdk/pkg/sync.(*syncer).syncResources(0x400874f200, {0xdbbd3e8?, 0x40085e2b70?})
	/xsrc/vendor/github.com/conductorone/baton-sdk/pkg/sync/syncer.go:834 +0x260
github.com/conductorone/baton-sdk/pkg/sync.(*syncer).SyncResources(0x400874f200, {0xdbbd3e8?, 0x400ffdd4d0?})
	/xsrc/vendor/github.com/conductorone/baton-sdk/pkg/sync/syncer.go:815 +0x2b8
github.com/conductorone/baton-sdk/pkg/sync.(*syncer).Sync(0x400874f200, {0xdbbd3e8?, 0x400ffdd320?})
	/xsrc/vendor/github.com/conductorone/baton-sdk/pkg/sync/syncer.go:468 +0xaf8
gitlab.com/ductone/c1/pkg/temporal/sync_activity/sync.(*SyncActivities).sync(0x4000c41a20, {0xdbbd3e8, 0x40065586c0}, 0x400c0b5860, 0x4008889860?, 0x4008ab8400, {0xdb9a0a0, 0x4006b5a740})
	/xsrc/pkg/temporal/sync_activity/sync/sync_v0.go:706 +0x31c0
gitlab.com/ductone/c1/pkg/temporal/sync_activity/sync.(*SyncActivities).syncEntrypoint(0x4000c41a20, {0xdbbd3e8, 0x400d969830}, 0x400c0b5860, {0x4006c098c0, 0x1b}, {0x4006c098e0, 0x1b})
	/xsrc/pkg/temporal/sync_activity/sync/sync_v0.go:1301 +0x576c
gitlab.com/ductone/c1/pkg/temporal/sync_activity/sync.(*SyncActivities).Sync(0x4000c41a20, {0xdbbd3e8, 0x400d969830}, 0x400c0b5860, {0x4006c098c0, 0x1b}, {0x4006c098e0, 0x1b})
	/xsrc/pkg/temporal/sync_activity/sync/sync_v0.go:945 +0x2bc
reflect.Value.call({0xa9c20a0?, 0x4001d9d3c0?, 0x40070d93e8?}, {0xc75e267, 0x4}, {0x40073cb8c0, 0x4, 0xd0ec0?})
	/usr/local/go/src/reflect/value.go:584 +0x978
reflect.Value.Call({0xa9c20a0?, 0x4001d9d3c0?, 0xa?}, {0x40073cb8c0?, 0x600000005?, 0xffff5aea6198?})
	/usr/local/go/src/reflect/value.go:368 +0x94
go.temporal.io/sdk/internal.executeFunction({0xa9c20a0, 0x4001d9d3c0}, {0x40098fe400, 0x4, 0xa3f5720?})
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_worker.go:2065 +0x214
go.temporal.io/sdk/internal.executeFunctionWithContext({0xdbbd3e8, 0x400d969830}, {0xa9c20a0, 0x4001d9d3c0}, {0x400d9695c0, 0x3, 0x3})
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_worker.go:2049 +0x158
go.temporal.io/sdk/internal.(*activityEnvironmentInterceptor).ExecuteActivity(0x40098fe380, {0xdbbd3e8?, 0x400d969800?}, 0x4014bd7440)
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_activity.go:370 +0x70
go.temporal.io/sdk/interceptor.(*tracingActivityInboundInterceptor).ExecuteActivity(0x4014bd7410, {0xdbbd490, 0x400ef57e30}, 0x4014bd7440)
	/xsrc/vendor/go.temporal.io/sdk/interceptor/tracing_interceptor.go:466 +0x30c
go.temporal.io/sdk/internal.(*activityExecutor).ExecuteWithActualArgs(0x4000c71c80, {0xdbbd490, 0x400ef57e30}, {0x400d9695c0, 0x3, 0x3})
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_worker.go:978 +0x134
go.temporal.io/sdk/internal.(*activityExecutor).Execute(0x4000c71c80, {0xdbbd490, 0x400ef57e30}, 0x40091deb00)
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_worker.go:964 +0x104
go.temporal.io/sdk/internal.(*activityTaskHandlerImpl).Execute(0x40001cd420, {0xc79fa85, 0xf}, 0x4006539880)
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_task_handlers.go:2286 +0x850
go.temporal.io/sdk/internal.(*activityTaskPoller).ProcessTask(0x4000ce24e0, {0xa5625a0, 0x4008a0f490})
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_task_pollers.go:1100 +0x20c
go.temporal.io/sdk/internal.(*baseWorker).processTaskAsync.func1()
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_worker_base.go:456 +0x104
created by go.temporal.io/sdk/internal.(*baseWorker).processTaskAsync in goroutine 107
	/xsrc/vendor/go.temporal.io/sdk/internal/internal_worker_base.go:435 +0x8c
	```