### PR TITLE
CXH-279: add missing Ramp user roles

### DIFF
--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -94,6 +94,8 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 
 	rv := []*v2.Grant{}
 	for _, user := range usersResponse.Users {
+		// Use exact match after stripping the "role:" prefix.
+		// strings.Contains would produce false positives — e.g. "role:GUEST_USER" contains "USER".
 		if strings.TrimPrefix(roleID, "role:") != user.Role {
 			continue
 		}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -39,6 +39,14 @@ var roles = []client.Role{
 		ID:   "IT_ADMIN",
 		Name: "IT Admin",
 	},
+	{
+		ID:   "AUDITOR",
+		Name: "Auditor",
+	},
+	{
+		ID:   "GUEST_USER",
+		Name: "Guest",
+	},
 }
 
 func (o *roleBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -86,7 +94,7 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 
 	rv := []*v2.Grant{}
 	for _, user := range usersResponse.Users {
-		if !strings.Contains(roleID, user.Role) {
+		if strings.TrimPrefix(roleID, "role:") != user.Role {
 			continue
 		}
 

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -96,8 +96,8 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 
 	rv := []*v2.Grant{}
 	for _, user := range usersResponse.Users {
-		// Use exact match after stripping the "role:" prefix.
-		// strings.Contains would produce false positives — e.g. "role:GUEST_USER" contains "USER".
+		// resource.Id.Resource is the ID set in List(): fmt.Sprintf("role:%s", role.ID).
+		// Strip that prefix before comparing to user.Role (the raw Ramp API value).
 		if strings.TrimPrefix(roleID, "role:") != user.Role {
 			continue
 		}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -18,6 +18,8 @@ type roleBuilder struct {
 	client *client.Client
 }
 
+// roles is the complete set of role values returned by the Ramp API.
+// See https://docs.ramp.com/developer-api/v1/api/users for the role enum.
 var roles = []client.Role{
 	{
 		ID:   "BUSINESS_ADMIN",


### PR DESCRIPTION
Adds the Auditor and Guest role types that were missing from the connector's role list, bringing it in line with all roles supported by the Ramp API. Also fixes a role-matching bug where grant assignment could produce false positives due to substring comparison.