### PR TITLE
CXH-1405: add vendors:write OAuth scope for vendor owner grant/revoke

### DIFF
--- a/cmd/baton-ramp/main.go
+++ b/cmd/baton-ramp/main.go
@@ -27,7 +27,8 @@ var version = "dev"
 // users:read    — list users (ListUsers)
 // users:write   — create/deactivate/reactivate users (CreateUser, DeactivateUser, ReactivateUser)
 // vendors:read  — list vendors (ListVendors, GetVendor)
-var rampOAuthScopes = []string{"users:read", "users:write", "vendors:read"}
+// vendors:write — update vendor owner (UpdateVendorOwner) for vendor owner grant/revoke
+var rampOAuthScopes = []string{"users:read", "users:write", "vendors:read", "vendors:write"}
 
 func main() {
 	ctx := context.Background()

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -149,7 +149,7 @@ The Ramp connector supports two authentication methods — pick one when populat
 - **Access Token** — a long-lived Ramp API access token.
 - **OAuth 2.0 Client Credentials** — a Ramp OAuth client ID and secret (the connector exchanges them for a short-lived access token automatically, via `https://api.ramp.com/developer/v1/token`).
 
-See the [Ramp authorization docs](https://docs.ramp.com/developer-api/v1/authorization) for how to create an OAuth app with the `Client Credentials` grant type and `users:read` / `users:write` scopes.
+See the [Ramp authorization docs](https://docs.ramp.com/developer-api/v1/authorization) for how to create an OAuth app with the `Client Credentials` grant type and `users:read`, `users:write`, `vendors:read`, and `vendors:write` scopes.
 
 The connector points at `https://api.ramp.com` by default. Set `BATON_RAMP_BASE_URL` (or the **Ramp API Base URL** field) to `https://demo-api.ramp.com` (or another Ramp environment) to override.
 


### PR DESCRIPTION
Adds the vendors:write OAuth scope so vendor owner grant/revoke works on OAuth2 client-credentials deployments.