### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -92,7 +92,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Ramp connector is now pulling access data into C1.
+**Done.** Your Ramp connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -171,6 +171,9 @@ stringData:
 
   # Ramp credentials
   BATON_TOKEN: <Ramp API token>
+
+  # Optional: include if you want C1 to provision access using this connector
+  BATON_PROVISIONING: true
 ```
 
 **Option B — OAuth 2.0 Client Credentials:**
@@ -190,6 +193,9 @@ stringData:
   # Ramp OAuth credentials
   BATON_RAMP_CLIENT_ID: <Ramp OAuth client ID>
   BATON_RAMP_CLIENT_SECRET: <Ramp OAuth client secret>
+
+  # Optional: include if you want C1 to provision access using this connector
+  BATON_PROVISIONING: true
 ```
 
 See the connector's README or run `--help` to see all available configuration flags and environment variables.
@@ -238,7 +244,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Ramp connector is now pulling access data into C1.
+**Done.** Your Ramp connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes:

- Restore `**Done.**` closing phrase (replaces `**That's it!**`)
- Restore `BATON_PROVISIONING: true` flag in both Kubernetes secrets blocks (Option A — Access Token, Option B — OAuth 2.0 Client Credentials)

These corrections prevent the sync bot from reintroducing regressions on future runs.