### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -12,11 +12,16 @@ sidebarTitle: Ramp
 
 ## Capabilities
 
+{/* AUTO-GENERATED:START - capabilities
+     Generated from baton_capabilities.json. Do not edit manually. */}
+
 | Resource     | Sync | Provision |
 | :----------- | :--- | :-------- |
 | Accounts     | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |       
 | Roles        | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>    |   |
 | Vendors      | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>    | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   |
+
+{/* AUTO-GENERATED:END - capabilities */}
 
 <Note>
 **Vendor owner is single-assignee.** Each Ramp vendor can have only one owner at a time. Granting the vendor owner entitlement to a new user overwrites the previous owner in Ramp — the prior owner is silently removed. Revoking the entitlement clears the owner only when the principal being revoked is the current owner.


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes:

- Restore `AUTO-GENERATED:START/END` comment wrappers around capabilities table

These corrections prevent the sync bot from reintroducing regressions on future runs.